### PR TITLE
Support RANGE_ADD with multiple edges on same mutation

### DIFF
--- a/lib/writeRelayUpdatePayload.js
+++ b/lib/writeRelayUpdatePayload.js
@@ -54,16 +54,16 @@ var warning = require('fbjs/lib/warning');
  * mixed.  Mixed is safer than any, but that safety comes from Flow forcing you
  * to inspect a mixed value at runtime before using it.  However these mixeds
  * are ending up everywhere and are not being inspected */
-var CLIENT_MUTATION_ID = RelayConnectionInterface.CLIENT_MUTATION_ID;
-var EDGES = RelayConnectionInterface.EDGES;
-var ANY_TYPE = RelayNodeInterface.ANY_TYPE;
-var ID = RelayNodeInterface.ID;
-var NODE = RelayNodeInterface.NODE;
-var APPEND = GraphQLMutatorConstants.APPEND;
-var IGNORE = GraphQLMutatorConstants.IGNORE;
-var PREPEND = GraphQLMutatorConstants.PREPEND;
-var REFETCH = GraphQLMutatorConstants.REFETCH;
-var REMOVE = GraphQLMutatorConstants.REMOVE;
+var CLIENT_MUTATION_ID = RelayConnectionInterface.CLIENT_MUTATION_ID,
+    EDGES = RelayConnectionInterface.EDGES;
+var ANY_TYPE = RelayNodeInterface.ANY_TYPE,
+    ID = RelayNodeInterface.ID,
+    NODE = RelayNodeInterface.NODE;
+var APPEND = GraphQLMutatorConstants.APPEND,
+    IGNORE = GraphQLMutatorConstants.IGNORE,
+    PREPEND = GraphQLMutatorConstants.PREPEND,
+    REFETCH = GraphQLMutatorConstants.REFETCH,
+    REMOVE = GraphQLMutatorConstants.REMOVE;
 
 
 var EDGES_FIELD = RelayQuery.Field.build({
@@ -86,8 +86,8 @@ var STUB_CURSOR_ID = 'client:cursor';
  * store.
  */
 function writeRelayUpdatePayload(writer, operation, payload, _ref) {
-  var configs = _ref.configs;
-  var isOptimisticUpdate = _ref.isOptimisticUpdate;
+  var configs = _ref.configs,
+      isOptimisticUpdate = _ref.isOptimisticUpdate;
 
   configs.forEach(function (config) {
     switch (config.type) {
@@ -268,53 +268,57 @@ function handleRangeAdd(writer, payload, operation, config, isOptimisticUpdate) 
   var store = writer.getRecordStore();
 
   // Extracts the new edge from the payload
-  var edge = getObject(payload, config.edgeName);
-  var edgeNode = edge && getObject(edge, NODE);
-  if (!edge || !edgeNode) {
-    return;
-  }
+  var res = getObjectOrArray(payload, config.edgeName);
+  var edges = Array.isArray(res) ? res : [res];
 
-  // Extract the id of the node with the connection that we are adding to.
-  var connectionParentID = config.parentID;
-  if (!connectionParentID) {
-    var edgeSource = getObject(edge, 'source');
-    if (edgeSource) {
-      connectionParentID = getString(edgeSource, ID);
+  edges.forEach(function (edge) {
+    var edgeNode = edge && getObject(edge, NODE);
+    if (!edge || !edgeNode) {
+      return;
     }
-  }
-  !connectionParentID ? process.env.NODE_ENV !== 'production' ? invariant(false, 'writeRelayUpdatePayload(): Cannot insert edge without a configured ' + '`parentID` or a `%s.source.id` field.', config.edgeName) : invariant(false) : void 0;
 
-  var nodeID = getString(edgeNode, ID) || generateClientID();
-  var cursor = edge.cursor || STUB_CURSOR_ID;
-  var edgeData = (0, _extends3['default'])({}, edge, {
-    cursor: cursor,
-    node: (0, _extends3['default'])({}, edgeNode, {
-      id: nodeID
-    })
-  });
+    // Extract the id of the node with the connection that we are adding to.
+    var connectionParentID = config.parentID;
+    if (!connectionParentID) {
+      var edgeSource = getObject(edge, 'source');
+      if (edgeSource) {
+        connectionParentID = getString(edgeSource, ID);
+      }
+    }
+    !connectionParentID ? process.env.NODE_ENV !== 'production' ? invariant(false, 'writeRelayUpdatePayload(): Cannot insert edge without a configured ' + '`parentID` or a `%s.source.id` field.', config.edgeName) : invariant(false) : void 0;
 
-  // add the node to every connection for this field
-  var connectionIDs = store.getConnectionIDsForField(connectionParentID, config.connectionName);
-  if (connectionIDs) {
-    connectionIDs.forEach(function (connectionID) {
-      return addRangeNode(writer, operation, config, connectionID, nodeID, edgeData);
+    var nodeID = getString(edgeNode, ID) || generateClientID();
+    var cursor = edge.cursor || STUB_CURSOR_ID;
+    var edgeData = (0, _extends3['default'])({}, edge, {
+      cursor: cursor,
+      node: (0, _extends3['default'])({}, edgeNode, {
+        id: nodeID
+      })
     });
-  }
 
-  if (isOptimisticUpdate) {
-    // optimistic updates need to record the generated client ID for
-    // a to-be-created node
-    RelayMutationTracker.putClientIDForMutation(nodeID, clientMutationID);
-  } else {
-    // non-optimistic updates check for the existence of a generated client
-    // ID (from the above `if` clause) and link the client ID to the actual
-    // server ID.
-    var clientNodeID = RelayMutationTracker.getClientIDForMutation(clientMutationID);
-    if (clientNodeID) {
-      RelayMutationTracker.updateClientServerIDMap(clientNodeID, nodeID);
-      RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+    // add the node to every connection for this field
+    var connectionIDs = store.getConnectionIDsForField(connectionParentID, config.connectionName);
+    if (connectionIDs) {
+      connectionIDs.forEach(function (connectionID) {
+        return addRangeNode(writer, operation, config, connectionID, nodeID, edgeData);
+      });
     }
-  }
+
+    if (isOptimisticUpdate) {
+      // optimistic updates need to record the generated client ID for
+      // a to-be-created node
+      RelayMutationTracker.putClientIDForMutation(nodeID, clientMutationID);
+    } else {
+      // non-optimistic updates check for the existence of a generated client
+      // ID (from the above `if` clause) and link the client ID to the actual
+      // server ID.
+      var clientNodeID = RelayMutationTracker.getClientIDForMutation(clientMutationID);
+      if (clientNodeID) {
+        RelayMutationTracker.updateClientServerIDMap(clientNodeID, nodeID);
+        RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+      }
+    }
+  });
 }
 
 /**

--- a/src/traversal/writeRelayUpdatePayload.js
+++ b/src/traversal/writeRelayUpdatePayload.js
@@ -327,73 +327,77 @@ function handleRangeAdd(
   const store = writer.getRecordStore();
 
   // Extracts the new edge from the payload
-  const edge = getObject(payload, config.edgeName);
-  const edgeNode = edge && getObject(edge, NODE);
-  if (!edge || !edgeNode) {
-    return;
-  }
+  const res = getObjectOrArray(payload, config.edgeName);
+  const edges = Array.isArray(res) ? res : [res];
 
-  // Extract the id of the node with the connection that we are adding to.
-  let connectionParentID = config.parentID;
-  if (!connectionParentID) {
-    const edgeSource = getObject(edge, 'source');
-    if (edgeSource) {
-      connectionParentID = getString(edgeSource, ID);
+  edges.forEach(edge => {
+    const edgeNode = edge && getObject(edge, NODE);
+    if (!edge || !edgeNode) {
+      return;
     }
-  }
-  invariant(
-    connectionParentID,
-    'writeRelayUpdatePayload(): Cannot insert edge without a configured ' +
-    '`parentID` or a `%s.source.id` field.',
-    config.edgeName
-  );
 
-  const nodeID = getString(edgeNode, ID) || generateClientID();
-  const cursor = edge.cursor || STUB_CURSOR_ID;
-  const edgeData = {
-    ...edge,
-    cursor: cursor,
-    node: {
-      ...edgeNode,
-      id: nodeID,
-    },
-  };
-
-  // add the node to every connection for this field
-  const connectionIDs =
-    store.getConnectionIDsForField(connectionParentID, config.connectionName);
-  if (connectionIDs) {
-    connectionIDs.forEach(connectionID => addRangeNode(
-      writer,
-      operation,
-      config,
-      connectionID,
-      nodeID,
-      edgeData
-    ));
-  }
-
-  if (isOptimisticUpdate) {
-    // optimistic updates need to record the generated client ID for
-    // a to-be-created node
-    RelayMutationTracker.putClientIDForMutation(
-      nodeID,
-      clientMutationID
+    // Extract the id of the node with the connection that we are adding to.
+    let connectionParentID = config.parentID;
+    if (!connectionParentID) {
+      const edgeSource = getObject(edge, 'source');
+      if (edgeSource) {
+        connectionParentID = getString(edgeSource, ID);
+      }
+    }
+    invariant(
+      connectionParentID,
+      'writeRelayUpdatePayload(): Cannot insert edge without a configured ' +
+      '`parentID` or a `%s.source.id` field.',
+      config.edgeName
     );
-  } else {
-    // non-optimistic updates check for the existence of a generated client
-    // ID (from the above `if` clause) and link the client ID to the actual
-    // server ID.
-    const clientNodeID =
-      RelayMutationTracker.getClientIDForMutation(clientMutationID);
-    if (clientNodeID) {
-      RelayMutationTracker.updateClientServerIDMap(
-        clientNodeID,
-        nodeID
-      );
-      RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+
+    const nodeID = getString(edgeNode, ID) || generateClientID();
+    const cursor = edge.cursor || STUB_CURSOR_ID;
+    const edgeData = {
+      ...edge,
+      cursor: cursor,
+      node: {
+        ...edgeNode,
+        id: nodeID,
+      },
+    };
+
+    // add the node to every connection for this field
+    const connectionIDs =
+      store.getConnectionIDsForField(connectionParentID, config.connectionName);
+    if (connectionIDs) {
+      connectionIDs.forEach(connectionID => addRangeNode(
+        writer,
+        operation,
+        config,
+        connectionID,
+        nodeID,
+        edgeData
+      ));
     }
-  }
+
+    if (isOptimisticUpdate) {
+      // optimistic updates need to record the generated client ID for
+      // a to-be-created node
+      RelayMutationTracker.putClientIDForMutation(
+        nodeID,
+        clientMutationID
+      );
+    } else {
+      // non-optimistic updates check for the existence of a generated client
+      // ID (from the above `if` clause) and link the client ID to the actual
+      // server ID.
+      const clientNodeID =
+        RelayMutationTracker.getClientIDForMutation(clientMutationID);
+      if (clientNodeID) {
+        RelayMutationTracker.updateClientServerIDMap(
+          clientNodeID,
+          nodeID
+        );
+        RelayMutationTracker.deleteClientIDForMutation(clientMutationID);
+      }
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
Support RANGE_ADD in which server return multiple edges to be added to a connection.

```js
{
  type: 'RANGE_ADD',
  parentName: 'crmEntity',
  parentID: this.props.entity.id,
  connectionName: 'timeline',
  edgeName: 'timelineEdges',
}
```
`timelineEdges` mutation output return `[ConnectionEdge]`.

Obs: Relay modern solve this with new mutation api, so this is just a temp fix.